### PR TITLE
Uri-escape metadata headers containing line feeds and other chars outside of the printable ASCII range

### DIFF
--- a/InternetArchive.NET/Item.cs
+++ b/InternetArchive.NET/Item.cs
@@ -128,7 +128,7 @@ public class Item
                     foreach (var kv in group)
                     {
                         string? val = kv.Value?.ToString() ?? throw new NullReferenceException();
-                        if (val.Any(x => x > 127))
+                        if (val.Any(chr => chr < 32 || chr > 126)) //printable ASCII range, except DEL (127)
                         {
                             val = $"uri({Uri.EscapeDataString(val)})";
                         }


### PR DESCRIPTION
Sending an HTML bucket description containing line breaks throws `System.FormatException: New-line characters are not allowed in header values.`.

Thank you for your consideration.